### PR TITLE
MonoDevelop 6.0 support

### DIFF
--- a/MarkdownViewer/MarkdownViewer.cs
+++ b/MarkdownViewer/MarkdownViewer.cs
@@ -1,24 +1,26 @@
-﻿using System;
+﻿using MonoDevelop.Core;
 using MonoDevelop.Ide.Gui;
 using MonoDevelop.Projects.Text;
 using Xwt;
 using Xwt.Drawing;
-using MonoDevelop.Core;
 
 namespace MarkdownViewer
 {
-	public class MarkdownViewer:AbstractBaseViewContent, IAttachableViewContent, IViewContent
+    public class MarkdownViewer: AbstractXwtViewContent
 	{
 		ScrollView scrollView;
-		MarkdownView markdownControl;
-		Document doc;
 
-		public MarkdownViewer (Document doc)
-		{
-			this.doc = doc;
-		}
+        MarkdownView markdownControl;
 
-		public override Gtk.Widget Control {
+        readonly Document doc;
+
+        public MarkdownViewer (Document doc)
+        {
+            this.doc = doc;
+            ContentName = "Markdown";
+        }
+
+        public override Widget Widget {
 			get {
 				if (scrollView == null) {
 					markdownControl = new MarkdownView ();
@@ -29,7 +31,7 @@ namespace MarkdownViewer
 					}
 					markdownControl.Font = markdownControl.Font.WithSize (11);
 					markdownControl.Margin = 30;
-					var frame = new FrameBox (markdownControl);
+                   	var frame = new FrameBox (markdownControl);
 					frame.MinWidth = 800;
 					frame.WidthRequest = 800;
 					frame.HorizontalPlacement = WidgetPlacement.Center;
@@ -40,129 +42,44 @@ namespace MarkdownViewer
 					frame.Margin = 10;
 					scrollView = new ScrollView (frame);
 				}
-				return (Gtk.Widget)Toolkit.CurrentEngine.GetNativeWidget (scrollView);
+				return scrollView;
 			}
 		}
 
-		void IAttachableViewContent.Selected ()
-		{
-			markdownControl.Markdown = doc.GetContent<ITextFile> ().Text;
-		}
-
-		void IAttachableViewContent.Deselected ()
-		{
-		}
-
-		void IAttachableViewContent.BeforeSave ()
-		{
-		}
-
-		void IAttachableViewContent.BaseContentChanged ()
-		{
-		}
-
-		event EventHandler IViewContent.BeforeSave { add { } remove { }
-		}
-
-		event EventHandler IViewContent.ContentChanged { add { } remove { }
-		}
-
-		event EventHandler IViewContent.ContentNameChanged { add { } remove { }
-		}
-
-		event EventHandler IViewContent.DirtyChanged { add { } remove { }
-		}
-
-		void IViewContent.Load (string fileName)
-		{
-		}
-
-		void IViewContent.LoadNew (System.IO.Stream content, string mimeType)
-		{
-		}
-
-		void IViewContent.Save (string fileName)
-		{
-		}
-
-		void IViewContent.Save ()
-		{
-		}
-
-		void IViewContent.DiscardChanges ()
-		{
-		}
-
-		MonoDevelop.Projects.Project IViewContent.Project {
-			get {
-				return null;
-			}
-			set {
-			}
-		}
-
-		string IViewContent.PathRelativeToProject {
-			get {
-				return "";
-			}
-		}
-
-		string IViewContent.ContentName {
-			get {
-				return TabPageLabel;
-			}
-			set { }
-		}
-
-		string IViewContent.UntitledName {
-			get {
-				return "";
-			}
-			set { }
-		}
-
-		string IViewContent.StockIconId {
+        public override string StockIconId {
 			get {
 				return null;
 			}
 		}
 
-		bool IViewContent.IsUntitled {
-			get {
-				return false;
-			}
-		}
-
-		bool IViewContent.IsViewOnly {
+        public override bool IsViewOnly {
 			get {
 				return true;
 			}
 		}
 
-		bool IViewContent.IsFile {
+        public override bool IsFile {
 			get {
 				return false;
 			}
 		}
 
-		bool IViewContent.IsDirty {
-			get {
-				return false;
-			}
-			set { }
-		}
-
-		bool IViewContent.IsReadOnly {
+        public override bool IsReadOnly {
 			get {
 				return true;
 			}
 		}
-
+     
 		public override string TabPageLabel {
 			get {
-				return GettextCatalog.GetString ("Markdown view");
+				return GettextCatalog.GetString (ContentName);
 			}
 		}
+
+        protected override void OnSelected ()
+        {
+        	markdownControl.Markdown = doc.GetContent<ITextFile> ().Text;
+        }
 	}
 }
 

--- a/MarkdownViewer/MarkdownViewer.csproj
+++ b/MarkdownViewer/MarkdownViewer.csproj
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MonoDevelop.Addins.0.3.16\build\net45\MonoDevelop.Addins.props" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.16\build\net45\MonoDevelop.Addins.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{39FE34F7-6D1A-427D-A52A-03566C42712C}</ProjectGuid>
-    <ProjectTypeGuids>{7DBEB09D-BB9F-4D92-A141-A009135475EF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{86F6BF2A-E449-4B3E-813B-9ACC37E5545F};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>MarkdownViewer</RootNamespace>
     <AssemblyName>MarkdownViewer</AssemblyName>
+	<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,21 +31,25 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="atk-sharp" />
-    <Reference Include="gtk-sharp" />
-    <Reference Include="gdk-sharp" />
-    <Reference Include="glib-sharp" />
-    <Reference Include="MonoDevelop.Ide">
-      <Package>C:\Program Files (x86)\Xamarin Studio\bin\MonoDevelop.Ide.dll</Package>
+    <Reference Include="atk-sharp">
+      <Package>gtk-sharp-3.0</Package>
     </Reference>
-    <Reference Include="MonoDevelop.Core">
-      <Package>C:\Program Files (x86)\Xamarin Studio\bin\MonoDevelop.Core.dll</Package>
+    <Reference Include="gtk-sharp">
+      <Package>gtk-sharp-3.0</Package>
+    </Reference>
+    <Reference Include="gdk-sharp">
+      <Package>gdk-sharp-3.0</Package>
+    </Reference>
+    <Reference Include="glib-sharp">
+      <Package>glib-sharp-3.0</Package>
+    </Reference>
+    <Reference Include="MonoDevelop.Ide">
+      <HintPath>lib\MonoDevelop.Ide.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xwt">
-      <Package>C:\Program Files (x86)\Xamarin Studio\bin\Xwt.dll</Package>
-    </Reference>
-    <Reference Include="ICSharpCode.NRefactory">
-      <Package>C:\Program Files (x86)\Xamarin Studio\bin\ICSharpCode.NRefactory.dll</Package>
+      <HintPath>..\packages\Xwt.0.2.17\lib\net40\Xwt.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -53,5 +59,14 @@
   <ItemGroup>
     <EmbeddedResource Include="Properties\Manifest.addin.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="lib\MonoDevelop.Ide.dll" />
+    <None Include="lib\MonoDevelop.Ide.dll.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="lib\" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MonoDevelop.Addins.0.3.16\build\net45\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.16\build\net45\MonoDevelop.Addins.targets')" />
 </Project>

--- a/MarkdownViewer/Properties/Manifest.addin.xml
+++ b/MarkdownViewer/Properties/Manifest.addin.xml
@@ -7,10 +7,6 @@
 		description="Markdown Viewer is used to view output of files with *.md/*.markdown extension like e.g. README.md."
 		category="IDE extensions"
 		version="1.0.0.2">
-	<Dependencies>
-		<Addin id="::MonoDevelop.Core" version="5.0" />
-		<Addin id="::MonoDevelop.Ide" version="5.0" />
-	</Dependencies>
 	<Extension path = "/MonoDevelop/Ide/StartupHandlers">
 		<Class class = "MarkdownViewer.SubviewAttachmentHandler"/>
 	</Extension>

--- a/MarkdownViewer/lib/MonoDevelop.Ide.dll.config
+++ b/MarkdownViewer/lib/MonoDevelop.Ide.dll.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<dllmap os="!windows,osx" dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libatk-1.0-0.dll" target="libatk-1.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgtk-win32-2.0-0.dll" target="libgtk-x11-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgdk-win32-2.0-0.dll" target="libgdk-x11-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libpango-1.0-0.dll" target="libpango-1.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libpangocairo-1.0-0.dll" target="libpangocairo-1.0.so.0"/>
+
+	<dllmap os="osx" dll="libglib-2.0-0.dll" target="libglib-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libatk-1.0-0.dll" target="libatk-1.0.0.dylib"/>
+	<dllmap os="osx" dll="libgtk-win32-2.0-0.dll" target="libgtk-quartz-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgdk-win32-2.0-0.dll" target="libgdk-quartz-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libpango-1.0-0.dll" target="libpango-1.0.0.dylib"/>
+	<dllmap os="osx" dll="libpangocairo-1.0-0.dll" target="libpangocairo-1.0.0.dylib"/>
+</configuration>

--- a/MarkdownViewer/packages.config
+++ b/MarkdownViewer/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MonoDevelop.Addins" version="0.3.16" targetFramework="net45" />
+  <package id="Xwt" version="0.2.17" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
- Convert to recent MonoDevelop API (AbstractXwtViewContent)
- Migrate to latest AddinMaker version as specified in https://mhut.ch/addinmaker/1.2
- Add Xwt package from NuGet
- Add MonoDevelop.Ide assembly from v6.1.2.44 to the project source